### PR TITLE
docs: add API docs for places autocomplete and day location stops (start/via/end)

### DIFF
--- a/Context.md
+++ b/Context.md
@@ -1,0 +1,115 @@
+MyTrip — https://github.com/AdarBahar/MyTrip
+
+Overview
+- MyTrip is a production-ready road trip planner with a FastAPI backend and a Next.js 14 frontend.
+- Core capabilities: trip days and stops (START/VIA/END), route optimization with GraphHopper, places search (type‑ahead + full search), and live location streaming via SSE.
+- This document orients new contributors and links to the most relevant in‑repo docs.
+
+Architecture (high level)
+- Backend (Python/FastAPI): backend/app/*
+  - Domain models: trips, days, stops, places, users; live location ingestion and stats
+  - Notable APIs: location ingestion + queries, SSE streaming, places search (suggest + search), stops management
+- Frontend (Next.js/TypeScript): frontend/*
+  - App Router, Tailwind, shadcn/ui, TanStack Query; SSE UI integration helpers
+- Data: MySQL 8 (primary), optional SQLite for tests; SQLAlchemy + Alembic
+- Maps/Routing: MapTiler (maps/geocoding), GraphHopper (routing)
+
+Key backend areas (selected)
+- Location module (PHP → FastAPI migration): backend/app/api/location/router.py
+  - Legacy‑compatible endpoints: POST /location/api/getloc, POST /location/api/driving, POST /location/api/batch-sync
+  - Queries: GET /location/api/locations, GET /location/api/driving-records, GET /location/api/users
+  - Stats + caching: GET/POST /location/api/stats (timeframe windows, optional segments)
+  - SSE streaming: GET /location/api/live/sse with “now” default when no since/Last-Event-ID
+  - Latest point: GET /location/api/live/latest
+- Places search (type‑ahead + full): backend/app/api/v1/places/endpoints.py
+  - GET /places/v1/places/suggest (requires session_token) — fast autocomplete
+  - GET /places/v1/places/search — comprehensive results with filters/sort/pagination
+- Stops/Days (trip planning): backend/app/api/stops/*, backend/app/schemas/stop.py
+  - START/VIA/END are all “stops” referencing a Place; constraints enforce START seq=1, END fixed
+
+Important docs and references (in repo)
+- API overview and references
+  - docs/api/reference.md (index) and docs/api/openapi.json (export)
+  - docs/api/places-autocomplete.md (autocomplete + full search)
+  - docs/api/day-locations.md (adding START/VIA/END to a day)
+- Architecture and guides
+  - docs/architecture/overview.md
+  - docs/guides/routing-profiles.md
+- Location/SSE UX
+  - frontend/docs/SSE_UI_INTEGRATION.md
+- Infrastructure/operational docs
+  - docs/SSL_SETUP.md, docs/CORS_FIX.md
+  - backend/docs/TESTING_CONFIGURATION.md
+  - backend/docs/route_optimization.md; docs/AI_ROUTE_OPTIMIZATION.md
+  - docs/COMPLETE_ENDPOINTS_API.md (coverage/status)
+
+Build, run, and tests (summary)
+- Local quick start (see README.md for complete details):
+  - Backend dev: cd backend && uvicorn app.main:app --reload (API at http://localhost:8000)
+  - Frontend dev: cd frontend && pnpm dev (UI at http://localhost:3500)
+  - Docker: make up / make down; migrations via make db.migrate
+- Tests (safe‑by‑default):
+  - cd backend && pytest -q (see backend/docs/TESTING_CONFIGURATION.md)
+  - Lint/format/type‑check: ruff, black, mypy (configured in backend/pyproject.toml)
+
+Deployment and production environments
+- Production API base (example): https://mytrips-api.bahar.co.il
+- SSL and CORS
+  - See docs/SSL_SETUP.md and docs/CORS_FIX.md
+  - README.md includes automated SSL helper scripts used on the server
+- Update/deploy (server‑side scripts)
+  - Typical backend update on server: sudo /opt/dayplanner/deployment/scripts/update.sh --backend-only && sudo systemctl restart dayplanner-backend
+  - Verify SSE proxy and behavior post‑deploy (examples):
+    - curl -sS https://mytrips-api.bahar.co.il/openapi.json | jq -r '.paths | keys[]' | grep '/api/location/live/sse'
+    - No‑backlog default: curl -N "https://mytrips-api.bahar.co.il/api/location/live/sse?users=Adar&heartbeat=5" | head -n 20
+    - Explicit backfill: curl -N "https://mytrips-api.bahar.co.il/api/location/live/sse?users=Adar&since=0&limit=50" | head -n 50
+- Compatibility note
+  - Code targets Python 3.11; a UTC fallback is implemented for Python 3.10 deployments (datetime.UTC → timezone.utc)
+
+What’s implemented (highlights)
+- Places search
+  - Autocomplete: /places/v1/places/suggest with session_token, debouncing guidance, proximity/category/country filters
+  - Full search: /places/v1/places/search with filters/sort/pagination
+  - Documentation: docs/api/places-autocomplete.md
+- Trip days and stops
+  - Model + API for START/VIA/END as Stops referencing Places; constraints and automatic route recompute
+  - Docs: docs/api/day-locations.md
+- Live location and SSE
+  - SSE default “start from now” when no since/Last-Event-ID provided
+  - Same‑origin SSE proxy endpoint to inject X-API-Token for EventSource
+  - Latest location and PHP‑compatible ingestion endpoints
+  - Frontend SSE guidelines: frontend/docs/SSE_UI_INTEGRATION.md
+- Operational improvements
+  - SSL/CORS guides, health endpoints, stats caching windows, and testing configuration
+
+What’s remaining / open items
+- Pre‑commit health and repo hygiene
+  - Align detect‑secrets baseline and versions; exclude build artifacts (frontend/.next) from hooks and git tracking
+  - Ensure .gitignore covers transient outputs; re‑enable hooks after fix
+- Deployment neutralization
+  - Confirm SSE proxy route is deployed/visible in openapi.json in production
+  - Roll out “now by default” SSE behavior to production and validate with curl
+- Frontend integration work
+  - Wire UI autocomplete to /places/v1/places/suggest (session_token lifecycle, debouncing)
+  - Final search experience via /places/v1/places/search
+  - Day editor: create/get Place then POST Stop (START/VIA/END) per docs/api/day-locations.md
+- Testing
+  - Expand integration tests around places endpoints and stops lifecycle
+  - Validate SSE behavior (no backlog by default; Last-Event-ID resume)
+- Documentation refinements
+  - Keep docs/api/reference.md and exported openapi.json in sync with backend endpoints
+
+Quick endpoint map (selected)
+- Places: GET /places/v1/places/suggest, GET /places/v1/places/search, GET /places/v1/places/{place_id}
+- Stops: POST /stops/{trip_id}/days/{day_id}/stops (create START/VIA/END), plus GET/PUT/DELETE
+- Location ingest (legacy‑compatible): POST /location/api/getloc, POST /location/api/driving, POST /location/api/batch-sync
+- Location queries: GET /location/api/locations, /driving-records, /users, /stats
+- Live/SSE: GET /location/api/live/latest, GET /location/api/live/sse (and same‑origin proxy)
+
+See also
+- README.md — quick start, stack and deployment notes
+- docs/architecture/overview.md — broader design context
+- docs/COMPLETE_ENDPOINTS_API.md — endpoint coverage and status
+- backend/docs/README.md and backend/docs/API_SUMMARY.md — backend‑centric overview
+- docs/api/day-locations.md and docs/api/places-autocomplete.md — detailed how‑tos
+

--- a/docs/api/day-locations.md
+++ b/docs/api/day-locations.md
@@ -1,0 +1,517 @@
+# Adding Locations to a Day
+
+This document describes how to add locations (start, end, or intermediate stops) to a day in a trip.
+
+## Overview
+
+To add a location to a day, you work with **Stops**. In your system:
+- **START** = Day's starting location (seq=1, fixed=true)
+- **END** = Day's ending location (fixed=true)
+- **VIA** = Intermediate stops along the route
+
+## Architecture
+
+Days don't directly store start/end locations. Instead, they're represented as **Stops** with specific `kind` values:
+- Each stop references a **Place** (via `place_id`)
+- Places store the actual location data (name, address, lat/lon)
+- Stops define the role and sequence of that place in the day's itinerary
+
+### Stop Kinds
+
+| Kind | Description | Constraints |
+|------|-------------|-------------|
+| `START` | Starting point of the route | Must be seq=1, fixed=true |
+| `VIA` | Intermediate waypoint | Can be optimized (fixed=false) |
+| `END` | Final destination | Must be fixed=true |
+
+### Stop Types
+
+Available stop types for categorization:
+- `ACCOMMODATION` - Hotels, hostels, camping
+- `FOOD` - Restaurants, cafes, food stops
+- `ATTRACTION` - Museums, landmarks, tourist sites
+- `SHOPPING` - Markets, malls, stores
+- `TRANSPORT` - Airports, train stations, bus terminals
+- `ACTIVITY` - Sports, adventures, experiences
+- `SCENIC` - Viewpoints, photo spots, natural beauty
+- `NIGHTLIFE` - Bars, clubs, entertainment venues
+- `OTHER` - Miscellaneous stops
+
+---
+
+## Step-by-Step Flow
+
+### Step 1: Create or Get the Place
+
+First, ensure the location exists as a Place in the database.
+
+#### Endpoint
+```
+POST /places
+```
+
+#### Request Body
+
+```json
+{
+  "name": "Grand Hotel Tel Aviv",
+  "address": "123 Main St, Tel Aviv, Israel",
+  "lat": 32.0853,
+  "lon": 34.7818,
+  "meta": {
+    "raw": {
+      "id": "maptiler_feature_id_123",
+      "place_id": "google_place_id_xyz"
+    }
+  }
+}
+```
+
+#### Required Fields
+
+| Field | Type | Range/Format | Description |
+|-------|------|--------------|-------------|
+| `name` | string | 1-255 chars | Place name |
+| `lat` | float | -90 to 90 | Latitude |
+| `lon` | float | -180 to 180 | Longitude |
+
+#### Optional Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `address` | string (max 500 chars) | Human-readable address |
+| `meta` | object | Additional metadata (provider IDs, raw data, etc.) |
+
+#### Response
+
+```json
+{
+  "id": "01K4AHPK4S1KVTYDB5ASTGTM8K",
+  "name": "Grand Hotel Tel Aviv",
+  "address": "123 Main St, Tel Aviv, Israel",
+  "lat": 32.0853,
+  "lon": 34.7818,
+  "meta": { ... },
+  "created_at": "2024-01-15T10:30:00Z",
+  "updated_at": "2024-01-15T10:30:00Z"
+}
+```
+
+---
+
+### Step 2: Create the Stop
+
+Once you have the `place_id`, create a stop for the day.
+
+#### Endpoint
+```
+POST /stops/{trip_id}/days/{day_id}/stops
+```
+
+#### Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `trip_id` | string | Trip identifier |
+| `day_id` | string | Day identifier |
+
+#### Required Fields
+
+| Field | Type | Description | Example |
+|-------|------|-------------|---------|
+| `place_id` | string | ID of the place from Step 1 | `"01K4AHPK4S1KVTYDB5ASTGTM8K"` |
+| `seq` | integer (> 0) | Sequence number in the day | `1` |
+| `kind` | enum | One of: `"start"`, `"via"`, `"end"` | `"start"` |
+
+#### Optional Fields
+
+| Field | Type | Description | Example |
+|-------|------|-------------|---------|
+| `fixed` | boolean | Whether stop position is fixed (default: false) | `true` |
+| `stop_type` | enum | Category of stop | `"accommodation"` |
+| `arrival_time` | string (ISO-8601 time) | Planned arrival time | `"14:30:00"` |
+| `departure_time` | string (ISO-8601 time) | Planned departure time | `"16:00:00"` |
+| `duration_minutes` | integer (> 0) | Planned duration at stop | `90` |
+| `priority` | integer (1-5) | Priority level (1=must-see, 5=backup) | `1` |
+| `notes` | string | Free-text notes | `"Hotel check-in at 3 PM"` |
+| `booking_info` | object | Reservation details | `{"confirmation": "ABC123"}` |
+| `contact_info` | object | Phone, website, email | `{"phone": "+972-3-1234567"}` |
+| `cost_info` | object | Estimated/actual costs | `{"amount": 150, "currency": "USD"}` |
+
+---
+
+## Examples
+
+### Example 1: Add START Location (Day Beginning)
+
+```json
+POST /stops/{trip_id}/days/{day_id}/stops
+
+{
+  "place_id": "01K4AHPK4S1KVTYDB5ASTGTM8K",
+  "seq": 1,
+  "kind": "start",
+  "fixed": true,
+  "stop_type": "accommodation",
+  "arrival_time": "15:00:00",
+  "departure_time": "09:00:00",
+  "duration_minutes": 720,
+  "priority": 1,
+  "notes": "Hotel check-in at 3 PM"
+}
+```
+
+### Example 2: Add END Location (Day Ending)
+
+```json
+POST /stops/{trip_id}/days/{day_id}/stops
+
+{
+  "place_id": "01K4AHPK4S1KVTYDB5ASTGTM8L",
+  "seq": 5,
+  "kind": "end",
+  "fixed": true,
+  "stop_type": "accommodation",
+  "arrival_time": "18:00:00",
+  "priority": 1,
+  "notes": "Hotel check-in"
+}
+```
+
+### Example 3: Add VIA Stop (Intermediate Stop)
+
+```json
+POST /stops/{trip_id}/days/{day_id}/stops
+
+{
+  "place_id": "01K4AHPK4S1KVTYDB5ASTGTM8M",
+  "seq": 2,
+  "kind": "via",
+  "fixed": false,
+  "stop_type": "food",
+  "arrival_time": "12:30:00",
+  "departure_time": "14:00:00",
+  "duration_minutes": 90,
+  "priority": 2,
+  "notes": "Lunch at local restaurant"
+}
+```
+
+---
+
+## Important Constraints
+
+### START Stops
+- ✅ Must have `seq = 1`
+- ✅ Must have `fixed = true`
+- ✅ Only one START per day
+
+### END Stops
+- ✅ Must have `fixed = true`
+- ✅ Can be any seq > 1
+
+### VIA Stops
+- ✅ Can have any seq > 1
+- ✅ Typically `fixed = false` (allows route optimization)
+
+### Sequence Numbers
+- ✅ Must be unique within a day
+- ✅ Must be > 0
+
+---
+
+## Automatic Behaviors
+
+After creating a stop, the system **automatically**:
+
+1. **Computes an optimized route** for the day
+2. **Commits it as the default route**
+3. **If you created an END stop**, it creates a START stop for the next day (inheriting the END location)
+
+This ensures that:
+- Routes are always up-to-date
+- Day transitions are seamless (Day N's end = Day N+1's start)
+- No manual route computation is needed
+
+---
+
+## Updating an Existing Stop
+
+### Endpoint
+```
+PATCH /stops/{trip_id}/days/{day_id}/stops/{stop_id}
+```
+
+### Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `trip_id` | string | Trip identifier |
+| `day_id` | string | Day identifier |
+| `stop_id` | string | Stop identifier |
+
+### Request Body (Partial Update)
+
+All fields are optional. Only include fields you want to update.
+
+```json
+{
+  "place_id": "01K4AHPK4S1KVTYDB5ASTGTM8N",
+  "arrival_time": "13:00:00",
+  "notes": "Updated arrival time"
+}
+```
+
+### Example
+
+```bash
+PATCH /stops/{trip_id}/days/{day_id}/stops/{stop_id}
+
+{
+  "arrival_time": "13:00:00",
+  "duration_minutes": 120,
+  "notes": "Extended lunch duration"
+}
+```
+
+---
+
+## Complete JavaScript Example
+
+### Adding a Day with Start and End
+
+```javascript
+// 1. Create start place
+const startPlace = await fetch('/places', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'Authorization': 'Bearer YOUR_TOKEN'
+  },
+  body: JSON.stringify({
+    name: "Tel Aviv Hotel",
+    address: "123 Dizengoff St, Tel Aviv",
+    lat: 32.0853,
+    lon: 34.7818
+  })
+});
+const startPlaceData = await startPlace.json();
+
+// 2. Create end place
+const endPlace = await fetch('/places', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'Authorization': 'Bearer YOUR_TOKEN'
+  },
+  body: JSON.stringify({
+    name: "Jerusalem Hotel",
+    address: "456 King David St, Jerusalem",
+    lat: 31.7683,
+    lon: 35.2137
+  })
+});
+const endPlaceData = await endPlace.json();
+
+// 3. Create START stop
+const startStop = await fetch(`/stops/${tripId}/days/${dayId}/stops`, {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'Authorization': 'Bearer YOUR_TOKEN'
+  },
+  body: JSON.stringify({
+    place_id: startPlaceData.id,
+    seq: 1,
+    kind: "start",
+    fixed: true,
+    stop_type: "accommodation",
+    departure_time: "09:00:00"
+  })
+});
+
+// 4. Create END stop
+const endStop = await fetch(`/stops/${tripId}/days/${dayId}/stops`, {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'Authorization': 'Bearer YOUR_TOKEN'
+  },
+  body: JSON.stringify({
+    place_id: endPlaceData.id,
+    seq: 2,
+    kind: "end",
+    fixed: true,
+    stop_type: "accommodation",
+    arrival_time: "18:00:00"
+  })
+});
+
+// 5. Add intermediate stops (optional)
+const viaStop = await fetch(`/stops/${tripId}/days/${dayId}/stops`, {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'Authorization': 'Bearer YOUR_TOKEN'
+  },
+  body: JSON.stringify({
+    place_id: "01K4AHPK4S1KVTYDB5ASTGTM8M",
+    seq: 2,  // Will shift END to seq=3 automatically
+    kind: "via",
+    fixed: false,
+    stop_type: "attraction",
+    arrival_time: "11:00:00",
+    departure_time: "13:00:00",
+    duration_minutes: 120,
+    priority: 2,
+    notes: "Visit museum"
+  })
+});
+```
+
+---
+
+## Retrieving Day Locations
+
+### Get Days with Locations Summary
+
+#### Endpoint
+```
+GET /days/summary?trip_id={trip_id}
+```
+
+#### Response
+
+```json
+{
+  "days": [
+    {
+      "id": "01K4AHPK4S1KVTYDB5ASTGTM8K",
+      "trip_id": "01K367ED2RPNS2H19J8PQDNXFB",
+      "seq": 1,
+      "status": "ACTIVE",
+      "rest_day": false,
+      "calculated_date": "2024-07-15"
+    }
+  ],
+  "locations": [
+    {
+      "day_id": "01K4AHPK4S1KVTYDB5ASTGTM8K",
+      "start": {
+        "id": "01K4AHPK4S1KVTYDB5ASTGTM8K",
+        "name": "Tel Aviv Hotel",
+        "address": "123 Dizengoff St, Tel Aviv",
+        "lat": 32.0853,
+        "lon": 34.7818
+      },
+      "end": {
+        "id": "01K4AHPK4S1KVTYDB5ASTGTM8L",
+        "name": "Jerusalem Hotel",
+        "address": "456 King David St, Jerusalem",
+        "lat": 31.7683,
+        "lon": 35.2137
+      },
+      "route_total_km": 65.4,
+      "route_total_min": 78.5
+    }
+  ]
+}
+```
+
+---
+
+## Error Handling
+
+### Common Errors
+
+#### 400 Bad Request - Invalid Sequence
+
+```json
+{
+  "detail": "START stops must have seq=1"
+}
+```
+
+#### 400 Bad Request - Duplicate Sequence
+
+```json
+{
+  "detail": "A stop with sequence number 2 already exists for this day"
+}
+```
+
+#### 404 Not Found - Invalid Place
+
+```json
+{
+  "detail": "Place not found"
+}
+```
+
+#### 403 Forbidden - Not Trip Owner
+
+```json
+{
+  "detail": "You must be the trip owner to modify stops"
+}
+```
+
+---
+
+## Best Practices
+
+### 1. Always Create Places First
+Before creating stops, ensure the place exists in the database. This allows:
+- Reuse of places across multiple trips
+- Consistent location data
+- Better search and autocomplete
+
+### 2. Use Proper Sequence Numbers
+- START: Always seq=1
+- VIA: seq=2, 3, 4, ...
+- END: Last sequence number
+
+### 3. Set Fixed Appropriately
+- START and END: Always `fixed=true`
+- VIA: Use `fixed=false` for flexible stops that can be reordered during optimization
+
+### 4. Leverage Automatic Route Computation
+The system automatically computes and commits routes after stop creation/update. No manual intervention needed.
+
+### 5. Use Stop Types for Better Organization
+Categorize stops with appropriate `stop_type` values for:
+- Better UI filtering and display
+- Route optimization hints
+- Trip planning insights
+
+### 6. Include Timing Information
+Provide `arrival_time`, `departure_time`, and `duration_minutes` for:
+- Realistic route planning
+- Time-based optimization
+- Schedule conflict detection
+
+---
+
+## Summary
+
+**To add a location to a day:**
+
+1. **Create/get the Place** → `POST /places` → Get `place_id`
+2. **Create the Stop** → `POST /stops/{trip_id}/days/{day_id}/stops` with:
+   - `place_id` from step 1
+   - `kind`: `"start"`, `"end"`, or `"via"`
+   - `seq`: Position in the day (START must be 1)
+   - `fixed`: `true` for START/END, `false` for VIA
+   - Optional: times, duration, type, notes, etc.
+
+The system automatically computes and commits the route after each stop creation/update.
+
+**Key Constraints:**
+- START stops: seq=1, fixed=true
+- END stops: fixed=true
+- VIA stops: seq>1, typically fixed=false
+- Sequence numbers must be unique within a day
+
+**Automatic Behaviors:**
+- Route computation and commit after stop changes
+- Next day's START creation when END is added

--- a/docs/api/places-autocomplete.md
+++ b/docs/api/places-autocomplete.md
@@ -1,0 +1,372 @@
+# Address Search Autocomplete API
+
+This document describes the endpoints available for address and place search autocomplete functionality.
+
+## Overview
+
+Your system provides **two main endpoints** for address/place search:
+
+1. **Type-ahead Suggestions** (`/places/v1/places/suggest`) - Fast autocomplete for UI
+2. **Full Place Search** (`/places/v1/places/search`) - Comprehensive search with details
+
+---
+
+## 1. Type-ahead Suggestions (Recommended for Autocomplete)
+
+### Endpoint
+```
+GET /places/v1/places/suggest
+```
+
+### Purpose
+Fast, lightweight autocomplete suggestions while the user is typing. Optimized for real-time performance (target <120ms).
+
+### Key Features
+- ⚡ **Fast Response**: Optimized for real-time typing
+- 🎯 **Proximity Bias**: Results prioritized by distance from lat/lng
+- 🏷️ **Category Filtering**: Filter by hotel, restaurant, museum, address, etc.
+- 🌍 **Geographic Filtering**: Limit results to specific countries or bounding box
+- ✨ **Text Highlighting**: Matching text highlighted with `<b>` tags for UI
+- 🔗 **Session Management**: Group related requests with session tokens
+
+### Required Parameters
+
+| Parameter | Type | Description | Example |
+|-----------|------|-------------|---------|
+| `q` | string | Search query (minimum 1 character) | `"montef"` |
+| `session_token` | string | Session token for grouping requests | `"st_abc123"` |
+
+### Optional Parameters
+
+| Parameter | Type | Range/Format | Description | Example |
+|-----------|------|--------------|-------------|---------|
+| `lat` | float | -90 to 90 | User latitude for proximity bias | `32.07` |
+| `lng` | float | -180 to 180 | User longitude for proximity bias | `34.78` |
+| `radius` | integer | 1-50000 | Bias radius in meters | `5000` |
+| `bbox` | string | `minLon,minLat,maxLon,maxLat` | Bounding box filter | `"34.7,32.0,34.8,32.1"` |
+| `countries` | string | ISO-3166-1 alpha-2 codes | Comma-separated country codes | `"IL,US"` |
+| `categories` | string | Category names | Comma-separated filters | `"hotel,restaurant,museum"` |
+| `lang` | string | BCP-47 code | Language code (default: `"en"`) | `"en"` |
+| `limit` | integer | 1-20 | Maximum results (default: 8) | `8` |
+
+### Example Request
+
+```bash
+GET /places/v1/places/suggest?q=montef&lat=32.07&lng=34.78&radius=5000&countries=IL&categories=hotel&session_token=st_123
+```
+
+### Response Format
+
+```json
+{
+  "session_token": "st_123",
+  "suggestions": [
+    {
+      "id": "place_001",
+      "name": "Hotel Montefiore",
+      "highlighted": "Hotel <b>Montef</b>iore",
+      "formatted_address": "36 Montefiore St, Tel Aviv, Israel",
+      "types": ["lodging"],
+      "center": {
+        "lat": 32.0753,
+        "lng": 34.7818
+      },
+      "distance_m": 450,
+      "confidence": 0.95,
+      "source": "internal"
+    }
+  ]
+}
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `session_token` | string | Echo of the request session token |
+| `suggestions` | array | List of place suggestions |
+| `suggestions[].id` | string | Unique place identifier |
+| `suggestions[].name` | string | Place name |
+| `suggestions[].highlighted` | string | Name with `<b>` tags for matching text |
+| `suggestions[].formatted_address` | string | Human-readable address |
+| `suggestions[].types` | array | Place type categories |
+| `suggestions[].center` | object | Geographic coordinates `{lat, lng}` |
+| `suggestions[].distance_m` | integer | Distance from query point in meters (if lat/lng provided) |
+| `suggestions[].confidence` | float | Confidence score 0-1 |
+| `suggestions[].source` | string | Data source identifier |
+
+### Usage Pattern
+
+1. **Create a new session_token** when user focuses on search input
+2. **Send requests** with same session_token for each keystroke
+3. **Debounce requests** by 150-250ms for optimal performance
+4. **Use returned suggestions** to populate dropdown/autocomplete UI
+5. **Reset session_token** when input loses focus or user selects a result
+
+### JavaScript Example
+
+```javascript
+// 1. Generate session token when input is focused
+let sessionToken = `st_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+
+// 2. Debounced autocomplete function
+const debounce = (fn, delay) => {
+  let timeoutId;
+  return (...args) => {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => fn(...args), delay);
+  };
+};
+
+// 3. Fetch suggestions
+const fetchSuggestions = async (query, userLat, userLng) => {
+  if (query.length < 1) return;
+
+  const params = new URLSearchParams({
+    q: query,
+    session_token: sessionToken,
+    limit: 8
+  });
+
+  if (userLat && userLng) {
+    params.append('lat', userLat);
+    params.append('lng', userLng);
+    params.append('radius', 5000);
+  }
+
+  const response = await fetch(`/places/v1/places/suggest?${params}`);
+  const data = await response.json();
+
+  // Render suggestions in dropdown
+  renderSuggestions(data.suggestions);
+};
+
+// 4. Attach to input with debouncing
+const debouncedFetch = debounce(fetchSuggestions, 200);
+
+searchInput.addEventListener('input', (e) => {
+  debouncedFetch(e.target.value, userLat, userLng);
+});
+
+// 5. Reset session token when input loses focus
+searchInput.addEventListener('blur', () => {
+  sessionToken = `st_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+});
+```
+
+---
+
+## 2. Full Place Search
+
+### Endpoint
+```
+GET /places/v1/places/search
+```
+
+### Purpose
+Comprehensive search with full details, metadata, and comprehensive information suitable for mapping, display, and detailed place information.
+
+### Key Features
+- Complete place details with contact information
+- Geographic coordinates and bounding boxes
+- Categories, ratings, and popularity scores
+- Timezone and metadata for each place
+- Pagination tokens for large result sets
+
+### Use Cases
+- Final search results after user selects from type-ahead suggestions
+- Comprehensive place discovery and exploration
+- Detailed place information for trip planning
+- Geographic search within specific areas or countries
+
+### Required Parameters
+
+| Parameter | Type | Description | Example |
+|-----------|------|-------------|---------|
+| `q` | string | Search query (minimum 1 character) | `"hotel montefiore"` |
+
+### Optional Parameters
+
+| Parameter | Type | Range/Format | Description | Example |
+|-----------|------|--------------|-------------|---------|
+| `lat` | float | -90 to 90 | User latitude for proximity bias | `32.07` |
+| `lng` | float | -180 to 180 | User longitude for proximity bias | `34.78` |
+| `radius` | integer | 1-50000 | Bias radius in meters | `10000` |
+| `bbox` | string | `minLon,minLat,maxLon,maxLat` | Bounding box filter | `"34.7,32.0,34.8,32.1"` |
+| `countries` | string | ISO-3166-1 alpha-2 codes | Comma-separated country codes | `"IL,US"` |
+| `categories` | string | Category names | Comma-separated filters | `"hotel,restaurant"` |
+| `lang` | string | BCP-47 code | Language code (default: `"en"`) | `"en"` |
+| `limit` | integer | 1+ | Maximum results per page | `10` |
+| `offset` | integer | 0+ | Result offset for pagination | `0` |
+| `open_now` | boolean | true/false | Filter for currently open POIs | `true` |
+| `sort` | string | `relevance`, `distance`, `rating`, `popularity` | Sort order (default: `relevance`) | `"rating"` |
+
+### Example Request
+
+```bash
+GET /places/v1/places/search?q=museum&lat=32.07&lng=34.78&countries=IL&sort=rating&limit=10
+```
+
+### Response Format
+
+```json
+{
+  "results": [
+    {
+      "id": "place_002",
+      "name": "Tel Aviv Museum of Art",
+      "formatted_address": "27 Shaul Hamelech Blvd, Tel Aviv, Israel",
+      "types": ["museum", "attraction"],
+      "center": {
+        "lat": 32.0776,
+        "lng": 34.7831
+      },
+      "bbox": {
+        "min_lat": 32.0770,
+        "min_lng": 34.7825,
+        "max_lat": 32.0782,
+        "max_lng": 34.7837
+      },
+      "score": 0.92
+    }
+  ],
+  "page_token": "page_10_1234567890",
+  "total_count": 45
+}
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `results` | array | List of search results |
+| `results[].id` | string | Unique place identifier |
+| `results[].name` | string | Place name |
+| `results[].formatted_address` | string | Human-readable address |
+| `results[].types` | array | Place type categories |
+| `results[].center` | object | Geographic coordinates `{lat, lng}` |
+| `results[].bbox` | object | Bounding box (if available) |
+| `results[].score` | float | Relevance score |
+| `page_token` | string | Token for next page (if more results available) |
+| `total_count` | integer | Total available results |
+
+---
+
+## 3. Legacy Search Endpoint (MapTiler-based)
+
+### Endpoint
+```
+GET /places/search
+```
+
+### Purpose
+Older search endpoint using MapTiler geocoding API with aggressive caching (5-minute TTL).
+
+### Required Parameters
+
+| Parameter | Type | Description | Example |
+|-----------|------|-------------|---------|
+| `query` | string | Search term (minimum 2 characters) | `"tel aviv"` |
+
+### Optional Parameters
+
+| Parameter | Type | Range/Format | Description | Example |
+|-----------|------|--------------|-------------|---------|
+| `lat` | float | -90 to 90 | Latitude for proximity search | `32.07` |
+| `lon` | float | -180 to 180 | Longitude for proximity search | `34.78` |
+| `radius` | integer | 1+ | Search radius in meters (default: 50000) | `50000` |
+| `limit` | integer | 1-50 | Maximum results (default: 10) | `10` |
+| `format` | string | `legacy`, `modern` | Response format (default: `modern`) | `"modern"` |
+
+### Example Request
+
+```bash
+GET /places/search?query=tel+aviv&lat=32.07&lon=34.78&radius=50000&limit=10&format=modern
+```
+
+### Features
+- Aggressive caching (5-minute TTL) for improved performance
+- Proximity-based search with lat/lon parameters
+- Integration with user's saved places
+- Modern pagination with navigation links
+
+---
+
+## Comparison Table
+
+| Feature | `/suggest` (Autocomplete) | `/search` (Full Search) | `/places/search` (Legacy) |
+|---------|---------------------------|-------------------------|---------------------------|
+| **Speed** | <120ms target | Slower, comprehensive | Cached (5-min TTL) |
+| **Min Query Length** | 1 character | 1 character | 2 characters |
+| **Highlighted Text** | ✅ Yes (`<b>` tags) | ❌ No | ❌ No |
+| **Session Token** | ✅ Required | ❌ Not used | ❌ Not used |
+| **Max Results** | 1-20 (default 8) | Configurable with pagination | 1-50 (default 10) |
+| **Proximity Bias** | ✅ Yes | ✅ Yes | ✅ Yes |
+| **Category Filtering** | ✅ Yes | ✅ Yes | ❌ No |
+| **Country Filtering** | ✅ Yes | ✅ Yes | ❌ No |
+| **Sorting Options** | ❌ No (by relevance) | ✅ Yes (relevance, distance, rating, popularity) | ❌ No |
+| **Use Case** | Real-time typing | Final results, detailed info | General search with caching |
+
+---
+
+## Recommendations
+
+### **For Autocomplete UI (Recommended):**
+
+✅ **Use:** `GET /places/v1/places/suggest`
+
+**Why:**
+- ⚡ Optimized for real-time typing (target <120ms)
+- ✨ Highlighted matching text with `<b>` tags
+- 🎯 Proximity-based ranking
+- 🔗 Session management for grouping requests
+- 🏷️ Category and country filtering
+
+### **For Full Search Results:**
+
+✅ **Use:** `GET /places/v1/places/search`
+
+**Why:**
+- Complete place details
+- Pagination support
+- Multiple sort options (relevance, distance, rating)
+- Comprehensive metadata
+
+### **For Cached General Search:**
+
+✅ **Use:** `GET /places/search`
+
+**Why:**
+- 5-minute caching for repeated queries
+- MapTiler geocoding API integration
+- Modern pagination support
+- Good for general search without advanced filtering
+
+---
+
+## Rate Limiting
+
+The `/suggest` endpoint includes rate limiting to prevent abuse:
+- **Limit:** Configurable per IP address
+- **Response:** HTTP 429 with `retry_after_ms` field when limit exceeded
+- **Recommendation:** Implement client-side debouncing (150-250ms) to stay within limits
+
+---
+
+## Error Responses
+
+All endpoints return standardized error responses:
+
+```json
+{
+  "error_code": "BAD_REQUEST",
+  "message": "Both lat and lng must be provided together",
+  "status": 400,
+  "retry_after_ms": null
+}
+```
+
+Common error codes:
+- `BAD_REQUEST` (400) - Invalid parameters
+- `RATE_LIMIT` (429) - Too many requests
+- `BACKEND_UNAVAILABLE` (500) - Internal server error


### PR DESCRIPTION
This PR adds two documentation files:

- docs/api/places-autocomplete.md
- docs/api/day-locations.md

Highlights:
- Type-ahead suggestions endpoint (/places/v1/places/suggest) with parameters, examples, and JS debounce/session_token usage
- Full search endpoint (/places/v1/places/search) with filters, sort, and pagination
- Day locations (START/VIA/END) using Places and Stops: constraints, examples, and best practices

No code changes, docs only.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author